### PR TITLE
Automate weekly chapters.json updates from Google Sheets

### DIFF
--- a/.github/workflows/sync-from-sheets.yml
+++ b/.github/workflows/sync-from-sheets.yml
@@ -1,0 +1,43 @@
+name: Sync chapters.json from Google Sheets
+
+on:
+  workflow_dispatch:  # ✅ allows manual trigger from Actions tab
+  schedule:
+    - cron: '0 9 * * 1'  # ✅ runs every Monday at 9:00 AM UTC (adjust as needed)
+
+permissions:
+  contents: write  # ✅ allows the bot to commit and push changes
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Sync from Google Sheets
+        run: node sync-from-sheets.js
+
+      - name: Commit and push if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          # Check if chapters.json has changes
+          if git diff --quiet chapters.json; then
+            echo "✅ No changes detected in chapters.json"
+          else
+            echo "📝 Changes detected, committing..."
+            git add chapters.json
+            git commit -m "Update chapters.json from Google Sheets"
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+            echo "✅ Successfully synced and pushed chapters.json"
+          fi

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,0 +1,89 @@
+# Automated Chapter Sync Documentation
+
+## Overview
+
+This repository has automated syncing from Google Sheets to `chapters.json`, which then triggers automatic chapter page generation.
+
+## How It Works
+
+### 1. **Google Sheets → chapters.json Sync**
+- **Script**: `sync-from-sheets.js`
+- **Workflow**: `.github/workflows/sync-from-sheets.yml`
+- **Schedule**: Runs every Monday at 9:00 AM UTC
+- **Manual Trigger**: Available via GitHub Actions tab
+
+The sync script:
+1. Fetches data from your Google Sheet as CSV
+2. Parses the columns: Title, Date, Slug, Korean Link, Summary
+3. Auto-generates the additional fields needed for chapters.json:
+   - `href`: Generated from slug
+   - `cover`: `assets/ch{N}-cover.jpg` (with `?v=2` for chapters 4-8)
+   - `hero`: `assets/ch{N}-hero.jpg` (with `?v=2` for chapters 4-8)
+   - `status`: Always set to "published"
+   - `contentHtml`: `content/chapter-{N}.html`
+4. Converts markdown formatting to HTML (`*text*` → `<em>text</em>`)
+5. Writes the updated `chapters.json`
+6. Commits and pushes if changes detected
+
+### 2. **chapters.json → Chapter Pages**
+- **Script**: `generate-chapters.js`
+- **Workflow**: `.github/workflows/auto-generate.yml`
+- **Trigger**: Automatically runs when `chapters.json` is updated
+
+This generates individual `.html` files for each chapter with proper Open Graph metadata for social sharing.
+
+## Workflow Sequence
+
+```
+Google Sheets (manual update)
+    ↓
+Weekly sync (or manual trigger)
+    ↓
+chapters.json updated
+    ↓
+Auto-generate workflow triggered
+    ↓
+Chapter .html pages created
+    ↓
+Changes pushed to GitHub
+    ↓
+Site deployed via GitHub Pages
+```
+
+## Manual Commands
+
+```bash
+# Sync from Google Sheets
+npm run sync:sheets
+
+# Generate chapter pages
+npm run build:chapters
+```
+
+## Google Sheet Structure
+
+Your sheet should have these columns in order:
+1. **Title** - Chapter title
+2. **Korean Title** - Korean translation (informational, not used in JSON)
+3. **Date** - Publication date (YYYY-MM-DD format)
+4. **Slug** - URL-friendly identifier (e.g., "vienna-bound-plane")
+5. **Korean Link** - Link to Korean version on mediabuddha.net
+6. **Summary** - Brief description (can use `*text*` for italic)
+
+## Important Notes
+
+- **Chapter Numbers**: Auto-assigned based on row order in the sheet (1st row = Chapter 1)
+- **Assets**: Make sure image files exist at `assets/ch{N}-cover.jpg` and `assets/ch{N}-hero.jpg`
+- **Content**: HTML content files should exist at `content/chapter-{N}.html`
+- **Summary Formatting**: Use `*word*` for italic text (converted to `<em>word</em>`)
+
+## Troubleshooting
+
+- **Sync not running**: Check GitHub Actions tab for errors
+- **Missing images**: Ensure assets follow the naming convention `ch{N}-cover.jpg`
+- **Wrong data**: Verify your Google Sheet has the correct column headers
+- **Manual sync needed**: Go to Actions → "Sync chapters.json from Google Sheets" → Run workflow
+
+## Google Sheet URL
+
+Your sheet: https://docs.google.com/spreadsheets/d/1rz1KvXpjPzf-hshLwg6PQG1aEGaogCGzULkiKN64Pd4/edit

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Static generator for Montafon Moonlight chapter OG pages",
   "type": "module",
   "scripts": {
-    "build:chapters": "node generate-chapters.js"
+    "build:chapters": "node generate-chapters.js",
+    "sync:sheets": "node sync-from-sheets.js"
   }
 }

--- a/sync-from-sheets.js
+++ b/sync-from-sheets.js
@@ -1,0 +1,129 @@
+/**
+ * sync-from-sheets.js
+ * Fetches data from Google Sheets and updates chapters.json
+ */
+
+import fs from "fs";
+import path from "path";
+import https from "https";
+
+const SHEET_ID = "1rz1KvXpjPzf-hshLwg6PQG1aEGaogCGzULkiKN64Pd4";
+const CSV_URL = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv`;
+
+function fetchCSV(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0' },
+      followRedirect: true
+    }, (res) => {
+      // Handle redirects
+      if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307) {
+        https.get(res.headers.location, (redirectRes) => {
+          let data = "";
+          redirectRes.on("data", chunk => data += chunk);
+          redirectRes.on("end", () => resolve(data));
+          redirectRes.on("error", reject);
+        }).on("error", reject);
+      } else {
+        let data = "";
+        res.on("data", chunk => data += chunk);
+        res.on("end", () => resolve(data));
+        res.on("error", reject);
+      }
+    }).on("error", reject);
+  });
+}
+
+function parseCSV(csvText) {
+  const lines = csvText.trim().split("\n");
+  const headers = lines[0].split(",").map(h => h.trim().replace(/^"|"$/g, ''));
+
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+
+    // Simple CSV parsing (handles quoted fields)
+    const values = [];
+    let current = "";
+    let inQuotes = false;
+
+    for (let j = 0; j < line.length; j++) {
+      const char = line[j];
+      if (char === '"') {
+        inQuotes = !inQuotes;
+      } else if (char === ',' && !inQuotes) {
+        values.push(current.trim().replace(/^"|"$/g, ''));
+        current = "";
+      } else {
+        current += char;
+      }
+    }
+    values.push(current.trim().replace(/^"|"$/g, ''));
+
+    const row = {};
+    headers.forEach((header, idx) => {
+      row[header] = values[idx] || "";
+    });
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function buildChaptersJSON(rows) {
+  return rows.map((row, index) => {
+    const chapterNum = index + 1;
+    const slug = row.Slug || row.slug || "";
+    let summary = row.Summary || row.summary || "";
+    // Convert markdown italic to HTML em tags
+    summary = summary.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+    const koreanLink = row["Korean Link"] || row["korean link"] || row.koreanLink || "";
+
+    // Determine version query param for cover/hero (chapters 4-8 have ?v=2)
+    let versionParam = "";
+    if (chapterNum >= 4 && chapterNum <= 8) {
+      versionParam = "?v=2";
+    }
+
+    return {
+      title: row.Title || row.title || "",
+      slug: slug,
+      href: `chapter.html?slug=${slug}`,
+      date: row.Date || row.date || "",
+      cover: `assets/ch${chapterNum}-cover.jpg${versionParam}`,
+      hero: `assets/ch${chapterNum}-hero.jpg${versionParam}`,
+      summary: summary,
+      status: "published",
+      contentHtml: `content/chapter-${chapterNum}.html`,
+      koreanLink: koreanLink
+    };
+  });
+}
+
+async function main() {
+  try {
+    console.log("📥 Fetching data from Google Sheets...");
+    const csvData = await fetchCSV(CSV_URL);
+
+    console.log("📊 Parsing CSV data...");
+    const rows = parseCSV(csvData);
+    console.log(`   Found ${rows.length} chapters`);
+
+    console.log("🔨 Building chapters.json structure...");
+    const chapters = buildChaptersJSON(rows);
+
+    console.log("💾 Writing to chapters.json...");
+    const outputPath = path.join(process.cwd(), "chapters.json");
+    fs.writeFileSync(outputPath, JSON.stringify(chapters, null, 2) + "\n");
+
+    console.log("✅ Successfully synced chapters.json from Google Sheets!");
+    console.log(`   Updated ${chapters.length} chapters`);
+
+  } catch (error) {
+    console.error("❌ Error syncing from Google Sheets:", error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
- Add sync-from-sheets.js script to fetch data from Google Sheets
- Create GitHub Actions workflow for weekly automated sync (Mondays 9AM UTC)
- Update package.json with sync:sheets npm script
- Add AUTOMATION.md documentation
- Script auto-generates missing fields (cover, hero, href, status, contentHtml)
- Handles markdown to HTML conversion in summaries
- Workflow can be triggered manually from Actions tab