### PR TITLE
Organize: Move generated chapter pages to og/ folder

### DIFF
--- a/generate-chapters.js
+++ b/generate-chapters.js
@@ -8,6 +8,7 @@ import path from "path";
 
 const BASE_URL = "https://omatty123.github.io/MontafonMoonlight/";
 const ROOT = process.cwd();
+const OG_DIR = path.join(ROOT, "og");
 
 const template = (chapter) => `
 <!DOCTYPE html>
@@ -23,7 +24,7 @@ const template = (chapter) => `
   <meta property="og:title" content="Montafon Moonlight – ${chapter.title}">
   <meta property="og:description" content="${chapter.summary.replace(/"/g, '&quot;')}">
   <meta property="og:image" content="${BASE_URL}${chapter.cover}">
-  <meta property="og:url" content="${BASE_URL}${chapter.slug}.html">
+  <meta property="og:url" content="${BASE_URL}og/${chapter.slug}.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -31,7 +32,7 @@ const template = (chapter) => `
   <meta name="twitter:description" content="${chapter.summary.replace(/"/g, '&quot;')}">
   <meta name="twitter:image" content="${BASE_URL}${chapter.cover}">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>
@@ -45,31 +46,49 @@ const template = (chapter) => `
 `;
 
 function cleanOldChapters() {
-  const files = fs.readdirSync(ROOT);
-  const htmlFiles = files.filter(f =>
+  // Clean old chapter files from root directory
+  console.log("🧹 Cleaning old chapter files from root...");
+  const rootFiles = fs.readdirSync(ROOT);
+  const htmlFiles = rootFiles.filter(f =>
     f.endsWith(".html") &&
     !["index.html", "chapter.html", "chapter-template.html",
       "chapter-maker.html", "404.html"].includes(f)
   );
   for (const f of htmlFiles) {
     fs.unlinkSync(path.join(ROOT, f));
-    console.log(`🗑️  Removed old ${f}`);
+    console.log(`   🗑️  Removed ${f} from root`);
+  }
+
+  // Clean old chapter files from og directory
+  if (fs.existsSync(OG_DIR)) {
+    console.log("🧹 Cleaning old chapter files from og/...");
+    const ogFiles = fs.readdirSync(OG_DIR);
+    for (const f of ogFiles.filter(f => f.endsWith(".html"))) {
+      fs.unlinkSync(path.join(OG_DIR, f));
+      console.log(`   🗑️  Removed ${f} from og/`);
+    }
   }
 }
 
 function main() {
   const chapters = JSON.parse(fs.readFileSync(path.join(ROOT, "chapters.json"), "utf8"));
-  console.log("🧹 Cleaning old static chapter files...");
+
   cleanOldChapters();
 
-  console.log("🪶 Generating new chapter pages...");
+  // Create og directory if it doesn't exist
+  if (!fs.existsSync(OG_DIR)) {
+    fs.mkdirSync(OG_DIR);
+    console.log("📁 Created og/ directory");
+  }
+
+  console.log("🪶 Generating chapter OG pages in og/...");
   const links = [];
   for (const ch of chapters) {
-    const filePath = path.join(ROOT, `${ch.slug}.html`);
+    const filePath = path.join(OG_DIR, `${ch.slug}.html`);
     fs.writeFileSync(filePath, template(ch));
-    const link = `${BASE_URL}${ch.slug}.html`;
+    const link = `${BASE_URL}og/${ch.slug}.html`;
     links.push(link);
-    console.log(`✅  Created ${filePath}`);
+    console.log(`   ✅  Created og/${ch.slug}.html`);
   }
 
   console.log("\n✨ All static OG pages ready for deploy.");

--- a/og/absolutesilence.html
+++ b/og/absolutesilence.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Absolute Silence">
   <meta property="og:description" content="Intrigued by Mr. Willi.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch5-cover.jpg?v=2">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/absolutesilence.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/absolutesilence.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Intrigued by Mr. Willi.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch5-cover.jpg?v=2">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/cheonmaneyo.html
+++ b/og/cheonmaneyo.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Cheonmaneyo">
   <meta property="og:description" content="Remembering Dr. Werner.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch4-cover.jpg?v=2">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/cheonmaneyo.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/cheonmaneyo.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Remembering Dr. Werner.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch4-cover.jpg?v=2">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/danube-taegeukgi.html
+++ b/og/danube-taegeukgi.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Taegeukgi on the Danube">
   <meta property="og:description" content="Explaining a different state of mind.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch15-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/danube-taegeukgi.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/danube-taegeukgi.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Explaining a different state of mind.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch15-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/deep-conversations-part-1.html
+++ b/og/deep-conversations-part-1.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Deep Conversations Part 1 - The World Unseen">
   <meta property="og:description" content="A friendship begins with a discussion of the world unseen.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch8-cover.jpg?v=2">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/deep-conversations-part-1.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/deep-conversations-part-1.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="A friendship begins with a discussion of the world unseen.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch8-cover.jpg?v=2">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/deep-conversations-part-2.html
+++ b/og/deep-conversations-part-2.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Deep Conversations Part 2 - The Raindrop Hwadu">
   <meta property="og:description" content="When you ask the right questions a level of transcendence opens.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch9-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/deep-conversations-part-2.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/deep-conversations-part-2.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="When you ask the right questions a level of transcendence opens.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch9-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/deep-conversations-part-3.html
+++ b/og/deep-conversations-part-3.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Deep Conversations Part 3 - The Absolute Silence Within">
   <meta property="og:description" content="Nature and our deepest mind hold an absolute silence.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch10-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/deep-conversations-part-3.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/deep-conversations-part-3.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Nature and our deepest mind hold an absolute silence.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch10-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/deep-conversations-part-4.html
+++ b/og/deep-conversations-part-4.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Deep Conversations Part 4 - 1,600 Meters Above Sea Level">
   <meta property="og:description" content="If you want a different experience, you have to go higher.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch11-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/deep-conversations-part-4.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/deep-conversations-part-4.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="If you want a different experience, you have to go higher.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch11-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/deep-conversations-part-5.html
+++ b/og/deep-conversations-part-5.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Deep Conversations Part 5 - Asceticism and Suffering">
   <meta property="og:description" content="From great suffering can come great insight.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch12-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/deep-conversations-part-5.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/deep-conversations-part-5.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="From great suffering can come great insight.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch12-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/deep-conversations-part-6.html
+++ b/og/deep-conversations-part-6.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Deep Conversations Part 6 - The Last Supper">
   <meta property="og:description" content="The absolute silence outside is the same as the one within.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch13-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/deep-conversations-part-6.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/deep-conversations-part-6.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="The absolute silence outside is the same as the one within.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch13-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/determination.html
+++ b/og/determination.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Determination">
   <meta property="og:description" content="Making the most of a sudden but intriguing opportunity.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch3-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/determination.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/determination.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Making the most of a sudden but intriguing opportunity.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch3-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/firstencounter.html
+++ b/og/firstencounter.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – First Encounter">
   <meta property="og:description" content="Meeting each other at last.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch7-cover.jpg?v=2">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/firstencounter.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/firstencounter.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Meeting each other at last.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch7-cover.jpg?v=2">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/jeong.html
+++ b/og/jeong.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Jeong">
   <meta property="og:description" content="Learning about <em>jeong</em>.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch6-cover.jpg?v=2">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/jeong.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/jeong.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Learning about <em>jeong</em>.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch6-cover.jpg?v=2">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/month-vacation.html
+++ b/og/month-vacation.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – A Month Long Vacation">
   <meta property="og:description" content="Thoughts of vacation bring the Author back to Mr. Willi">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch19-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/month-vacation.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/month-vacation.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Thoughts of vacation bring the Author back to Mr. Willi">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch19-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/night-in-krems.html
+++ b/og/night-in-krems.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – A Night in Krems">
   <meta property="og:description" content="Rehearsing old teachings for a new audience.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch16-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/night-in-krems.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/night-in-krems.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Rehearsing old teachings for a new audience.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch16-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/so-long-montafon.html
+++ b/og/so-long-montafon.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – So Long, Montafon">
   <meta property="og:description" content="Saying goodbye—for now.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch14-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/so-long-montafon.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/so-long-montafon.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Saying goodbye—for now.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch14-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/special-lecture.html
+++ b/og/special-lecture.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – A Special Lecture and Recital">
   <meta property="og:description" content="Korean voices echoing through Austrian minds">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch18-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/special-lecture.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/special-lecture.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Korean voices echoing through Austrian minds">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch18-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/three-phonecalls.html
+++ b/og/three-phonecalls.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Three Phonecalls">
   <meta property="og:description" content="Three calls force a decision that could no longer be avoided.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch2-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/three-phonecalls.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/three-phonecalls.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Three calls force a decision that could no longer be avoided.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch2-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/vienna-bound-plane.html
+++ b/og/vienna-bound-plane.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – Vienna Bound Plane">
   <meta property="og:description" content="Waiting for the flight to Vienna, a time to ponder how we got to this point.">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch1-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/vienna-bound-plane.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/vienna-bound-plane.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="Waiting for the flight to Vienna, a time to ponder how we got to this point.">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch1-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>

--- a/og/warm-river-water.html
+++ b/og/warm-river-water.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Montafon Moonlight – The Sound of Warm River Water">
   <meta property="og:description" content="What's keeping the author up at night?">
   <meta property="og:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch17-cover.jpg">
-  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/warm-river-water.html">
+  <meta property="og:url" content="https://omatty123.github.io/MontafonMoonlight/og/warm-river-water.html">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   <meta name="twitter:description" content="What's keeping the author up at night?">
   <meta name="twitter:image" content="https://omatty123.github.io/MontafonMoonlight/assets/ch17-cover.jpg">
 
-  <link rel="stylesheet" href="assets/all-serif.css">
+  <link rel="stylesheet" href="../assets/all-serif.css">
 </head>
 <body>
   <script>


### PR DESCRIPTION
- Update generate-chapters.js to output to og/ directory
- Clean all old chapter HTML files from root
- Root now only contains essential HTML files (index, 404, chapter, etc.)
- Generated OG pages now at: /og/{slug}.html
- Updated CSS link path to ../assets/all-serif.css